### PR TITLE
Add styled upload flow with preview truncation

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,25 +4,34 @@ import JsonPreview from './components/JsonPreview';
 import LintAccordion from './components/LintAccordion';
 import MinDaysInput from './components/MinDaysInput';
 import OptimizeButton from './components/OptimizeButton';
+import InconsistencyPanel from './components/InconsistencyPanel';
+import MinAssistButton from './components/MinAssistButton';
 import { FileProvider, useFile } from './context/FileContext';
 import { Toaster } from 'react-hot-toast';
 import { useState } from 'react';
+import styles from './components/UI.module.css';
 
 function Inner() {
   const [min, setMin] = useState('');
   const { fileId } = useFile();
 
   return (
-    <div className="flex flex-col items-center">
-      <h1 className="text-[40px] mt-[25px] font-normal">Optimización de Puestsos</h1>
-      <div className="flex flex-col items-center mt-10 space-y-4">
-        <FileUploader />
-        <OptimizeButton minDays={min} />
-        <MinDaysInput value={min} onChange={setMin} />
-      </div>
-      <JsonPreview />
-      <LintAccordion />
-    </div>
+    <>
+      <header className={styles.header} />
+      <main className={styles.main}>
+        <section>
+          <JsonPreview />
+          <InconsistencyPanel />
+          <LintAccordion />
+        </section>
+        <section className={styles.buttons}>
+          <FileUploader />
+          <OptimizeButton minDays={min} />
+          <MinAssistButton />
+          <MinDaysInput value={min} onChange={setMin} />
+        </section>
+      </main>
+    </>
   );
 }
 

--- a/client/src/components/FileUploader.jsx
+++ b/client/src/components/FileUploader.jsx
@@ -1,27 +1,35 @@
 // Component to upload a JSON file
-import { useRef } from 'react';
+import { useRef, useState } from 'react';
 import api from '../api/axios';
 import { toast } from 'react-hot-toast';
 import { useFile } from '../context/FileContext';
+import styles from './UI.module.css';
 
 export default function FileUploader() {
   const inputRef = useRef();
   const { setFileId, setLint, setSummary, setSample } = useFile();
+  const [fileName, setFileName] = useState(() => localStorage.getItem('lastFileName') || '');
+  const [loading, setLoading] = useState(false);
 
   const onChange = async (e) => {
     const file = e.target.files[0];
     if (!file) return;
     const form = new FormData();
     form.append('file', file);
+    setLoading(true);
     try {
       const { data } = await api.post('/files', form);
       setFileId(data.id);
       setSummary(data.summary);
       setSample(data.sample);
       setLint([]);
+      setFileName(file.name);
+      localStorage.setItem('lastFileName', file.name);
       toast.success('Archivo cargado');
     } catch (_) {
       // error toast handled by interceptor
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -32,14 +40,17 @@ export default function FileUploader() {
         type="file"
         accept="application/json"
         onChange={onChange}
-        className="hidden"
+        className={styles.hiddenInput}
       />
       <button
-        className="bg-[#2ECC71] text-black rounded-full shadow-lg px-8 py-2 text-xl"
+        className={`${styles.btn} ${styles.btnGreen}`}
         onClick={() => inputRef.current.click()}
+        aria-label="Cargar archivo"
       >
         Cargar archivo
       </button>
+      {fileName && <span className={styles.fileName}>{fileName}</span>}
+      {loading && <span className={styles.loader} />}
     </div>
   );
 }

--- a/client/src/components/InconsistencyPanel.jsx
+++ b/client/src/components/InconsistencyPanel.jsx
@@ -1,0 +1,21 @@
+import checkJsonConsistency from '../utils/checkJsonConsistency';
+import { useFile } from '../context/FileContext';
+import styles from './UI.module.css';
+
+export default function InconsistencyPanel() {
+  const { sample } = useFile();
+  const issues = checkJsonConsistency(sample);
+
+  if (!issues.length) return null;
+
+  return (
+    <div className={styles.previewBox} aria-label="panel-inconsistencias">
+      <h2>Inconsistencias</h2>
+      <ul>
+        {issues.map((i, idx) => (
+          <li key={idx}>{i}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/components/JsonPreview.jsx
+++ b/client/src/components/JsonPreview.jsx
@@ -1,14 +1,20 @@
 // Display uploaded JSON summary and sample
 import { useFile } from '../context/FileContext';
+import styles from './UI.module.css';
 
 export default function JsonPreview() {
   const { summary, sample } = useFile();
 
   if (!summary) return null;
+  const lines = JSON.stringify({ summary, sample }, null, 2).split('\n');
+  const preview = lines.slice(0, 40).join('\n') + (lines.length > 40 ? '\u2026' : '');
+
   return (
-    <div className="bg-[#D9D9D9] p-4 mt-4 rounded">
-      <h2 className="text-2xl mb-2">Preview Archivo Json</h2>
-      <pre className="text-sm">{JSON.stringify({ summary, sample }, null, 2)}</pre>
+    <div>
+      <h2>Preview Archivo Json</h2>
+      <div className={styles.previewBox}>
+        <pre>{preview}</pre>
+      </div>
     </div>
   );
 }

--- a/client/src/components/MinAssistButton.jsx
+++ b/client/src/components/MinAssistButton.jsx
@@ -1,0 +1,9 @@
+import styles from './UI.module.css';
+
+export default function MinAssistButton() {
+  return (
+    <button className={`${styles.btn} ${styles.btnGrey}`} disabled aria-label="minimo-asistencias">
+      Mínimo de Asistencias
+    </button>
+  );
+}

--- a/client/src/components/OptimizeButton.jsx
+++ b/client/src/components/OptimizeButton.jsx
@@ -2,6 +2,7 @@
 import api from '../api/axios';
 import { toast } from 'react-hot-toast';
 import { useFile } from '../context/FileContext';
+import styles from './UI.module.css';
 
 export default function OptimizeButton({ minDays }) {
   const { fileId, lint } = useFile();
@@ -16,9 +17,10 @@ export default function OptimizeButton({ minDays }) {
 
   return (
     <button
-      className="bg-[#E74C3C] text-black rounded-full shadow-lg px-8 py-2 text-xl disabled:opacity-50"
+      className={`${styles.btn} ${styles.btnRed}`}
       onClick={click}
       disabled={!fileId || hasErrors}
+      aria-label="Optimizar"
     >
       Optimizar
     </button>

--- a/client/src/components/UI.module.css
+++ b/client/src/components/UI.module.css
@@ -1,0 +1,94 @@
+.header {
+  background: linear-gradient(var(--yellow-top), var(--yellow-bg));
+  clip-path: polygon(0 0, 100% 0, 100% 80%, 0 100%);
+  height: 120px;
+}
+
+.main {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  justify-content: center;
+  padding: 2rem;
+}
+
+@media (max-width: 768px) {
+  .main {
+    flex-direction: column;
+  }
+}
+
+.previewBox {
+  background: #E5E5E5;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  max-height: 400px;
+  overflow-y: auto;
+  white-space: pre;
+  font-family: 'Courier New', monospace;
+}
+
+.buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.btn {
+  border-radius: 2rem;
+  font-size: 1.25rem;
+  padding: 0.9rem 2.5rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.btn:hover:not(:disabled) {
+  transform: scale(1.03);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.btnGreen {
+  background: var(--green-btn);
+  color: #000;
+}
+
+.btnGreen:hover:not(:disabled) {
+  background: var(--green-hov);
+}
+
+.btnRed {
+  background: var(--red-btn);
+  color: #000;
+}
+
+.btnRed:hover:not(:disabled) {
+  background: var(--red-hov);
+}
+
+.btnGrey {
+  background: var(--grey-btn);
+  color: var(--grey-text);
+}
+
+.fileName {
+  margin-left: 1rem;
+}
+
+.loader {
+  width: 24px;
+  height: 24px;
+  border: 4px solid var(--grey-text);
+  border-top-color: transparent;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-left: 0.5rem;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.hiddenInput {
+  display: none;
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -7,6 +7,17 @@ body {
   font-family: 'Inter', sans-serif;
 }
 
+:root {
+  --yellow-bg: #FCD858;
+  --yellow-top: #FFB326;
+  --green-btn: #32D657;
+  --green-hov: #24B648;
+  --red-btn: #E64444;
+  --red-hov: #C93636;
+  --grey-btn: #F0F0F0;
+  --grey-text: #9A9A9A;
+}
+
 .folder-bg {
   position: relative;
   min-height: 100vh;

--- a/client/src/utils/checkJsonConsistency.js
+++ b/client/src/utils/checkJsonConsistency.js
@@ -1,0 +1,12 @@
+export default function checkJsonConsistency(data) {
+  const issues = [];
+  if (!data) return issues;
+  const employees = data.Employees || [];
+  const days = data.Days_E || {};
+  employees.forEach((e) => {
+    if (!Array.isArray(days[e]) || days[e].length === 0) {
+      issues.push(`Empleado ${e} sin días asignados`);
+    }
+  });
+  return issues;
+}


### PR DESCRIPTION
## Summary
- polish index.css and define CSS variables
- add reusable UI styles module
- show file name and loader on upload
- truncate preview to 40 lines and show inconsistency panel
- restructure app layout with decorative header
- add placeholder button for minimum assistances
- include utility for basic consistency check

## Testing
- `npm test --prefix client` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `pytest -q server/tests` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_684f81638168832a86f989fcf49028b3