### PR TITLE
UI lint panel and layout

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -6,7 +6,7 @@
     <title>Opt Puestos</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400&display=swap" rel="stylesheet" />
   </head>
-  <body class="folder-bg">
+  <body>
     <div id="root"></div>
     <script type="module" src="/src/main.jsx"></script>
   </body>

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,35 +1,26 @@
 // Root component applying the folder theme and arranging UI elements
-import FileUploader from './components/FileUploader';
 import JsonPreview from './components/JsonPreview';
-import LintAccordion from './components/LintAccordion';
-import MinDaysInput from './components/MinDaysInput';
-import OptimizeButton from './components/OptimizeButton';
-import InconsistencyPanel from './components/InconsistencyPanel';
-import MinAssistButton from './components/MinAssistButton';
-import { FileProvider, useFile } from './context/FileContext';
+import LintPanel from './components/LintPanel';
+import ActionButtons from './components/ActionButtons';
+import IssuesPanel from './components/IssuesPanel';
+import { FileProvider } from './context/FileContext';
 import { Toaster } from 'react-hot-toast';
 import { useState } from 'react';
 import styles from './components/UI.module.css';
 
 function Inner() {
   const [min, setMin] = useState('');
-  const { fileId } = useFile();
 
   return (
     <>
       <header className={styles.header} />
       <main className={styles.main}>
-        <section>
+        <div className={styles.grid}>
           <JsonPreview />
-          <InconsistencyPanel />
-          <LintAccordion />
-        </section>
-        <section className={styles.buttons}>
-          <FileUploader />
-          <OptimizeButton minDays={min} />
-          <MinAssistButton />
-          <MinDaysInput value={min} onChange={setMin} />
-        </section>
+          <LintPanel />
+        </div>
+        <ActionButtons min={min} setMin={setMin} />
+        <IssuesPanel />
       </main>
     </>
   );

--- a/client/src/components/ActionButtons.jsx
+++ b/client/src/components/ActionButtons.jsx
@@ -1,0 +1,17 @@
+// Group upload and optimize controls
+import FileUploader from './FileUploader';
+import OptimizeButton from './OptimizeButton';
+import MinDaysInput from './MinDaysInput';
+import MinAssistText from './MinAssistText';
+import styles from './UI.module.css';
+
+export default function ActionButtons({ min, setMin }) {
+  return (
+    <div className={styles.buttons}>
+      <FileUploader />
+      <OptimizeButton minDays={min} />
+      <MinAssistText />
+      <MinDaysInput value={min} onChange={setMin} />
+    </div>
+  );
+}

--- a/client/src/components/FileUploader.jsx
+++ b/client/src/components/FileUploader.jsx
@@ -1,12 +1,11 @@
 // Component to upload a JSON file
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import api from '../api/axios';
 import { toast } from 'react-hot-toast';
 import { useFile } from '../context/FileContext';
 import styles from './UI.module.css';
 
 export default function FileUploader() {
-  const inputRef = useRef();
   const { setFileId, setLint, setSummary, setSample } = useFile();
   const [fileName, setFileName] = useState(() => localStorage.getItem('lastFileName') || '');
   const [loading, setLoading] = useState(false);
@@ -36,19 +35,19 @@ export default function FileUploader() {
   return (
     <div>
       <input
-        ref={inputRef}
+        id="file-input"
         type="file"
         accept="application/json"
         onChange={onChange}
         className={styles.hiddenInput}
       />
-      <button
+      <label
+        htmlFor="file-input"
         className={`${styles.btn} ${styles.btnGreen}`}
-        onClick={() => inputRef.current.click()}
         aria-label="Cargar archivo"
       >
         Cargar archivo
-      </button>
+      </label>
       {fileName && <span className={styles.fileName}>{fileName}</span>}
       {loading && <span className={styles.loader} />}
     </div>

--- a/client/src/components/IssuesPanel.jsx
+++ b/client/src/components/IssuesPanel.jsx
@@ -1,15 +1,16 @@
+// Shows data issues from sample
 import checkJsonConsistency from '../utils/checkJsonConsistency';
 import { useFile } from '../context/FileContext';
 import styles from './UI.module.css';
 
-export default function InconsistencyPanel() {
+export default function IssuesPanel() {
   const { sample } = useFile();
   const issues = checkJsonConsistency(sample);
 
   if (!issues.length) return null;
 
   return (
-    <div className={styles.previewBox} aria-label="panel-inconsistencias">
+    <div className={styles.previewBox} role="alert">
       <h2>Inconsistencias</h2>
       <ul>
         {issues.map((i, idx) => (

--- a/client/src/components/JsonPreview.jsx
+++ b/client/src/components/JsonPreview.jsx
@@ -10,7 +10,7 @@ export default function JsonPreview() {
   const preview = lines.slice(0, 40).join('\n') + (lines.length > 40 ? '\u2026' : '');
 
   return (
-    <div>
+    <div className={styles.preview}>
       <h2>Preview Archivo Json</h2>
       <div className={styles.previewBox}>
         <pre>{preview}</pre>

--- a/client/src/components/LintPanel.jsx
+++ b/client/src/components/LintPanel.jsx
@@ -1,9 +1,10 @@
-// Accordion listing lint messages
+// Shows lint result from backend
 import { useEffect } from 'react';
 import api from '../api/axios';
 import { useFile } from '../context/FileContext';
+import styles from './UI.module.css';
 
-export default function LintAccordion() {
+export default function LintPanel() {
   const { fileId, lint, setLint } = useFile();
 
   useEffect(() => {
@@ -13,13 +14,9 @@ export default function LintAccordion() {
 
   if (!lint.length) return null;
   return (
-    <details className="mt-4">
-      <summary>Lint Result</summary>
-      <ul>
-        {lint.map((e, idx) => (
-          <li key={idx}>{e.severity}: {e.msg}</li>
-        ))}
-      </ul>
-    </details>
+    <div className={`${styles.lintBox} ${styles.lint} ${styles.preview}`} role="alert">
+      <h2>Lint Result</h2>
+      <pre>{lint.map((e) => `${e.severity}: ${e.msg}`).join('\n')}</pre>
+    </div>
   );
 }

--- a/client/src/components/MinAssistButton.jsx
+++ b/client/src/components/MinAssistButton.jsx
@@ -1,9 +1,0 @@
-import styles from './UI.module.css';
-
-export default function MinAssistButton() {
-  return (
-    <button className={`${styles.btn} ${styles.btnGrey}`} disabled aria-label="minimo-asistencias">
-      Mínimo de Asistencias
-    </button>
-  );
-}

--- a/client/src/components/MinAssistText.jsx
+++ b/client/src/components/MinAssistText.jsx
@@ -1,0 +1,6 @@
+// Static text for minimum assists
+import styles from './UI.module.css';
+
+export default function MinAssistText() {
+  return <span className={styles.minAssist}>Mínimo de Asistencias</span>;
+}

--- a/client/src/components/UI.module.css
+++ b/client/src/components/UI.module.css
@@ -1,15 +1,16 @@
 .header {
-  background: linear-gradient(var(--yellow-top), var(--yellow-bg));
+  background: linear-gradient(var(--top-yellow), var(--bg-yellow));
   clip-path: polygon(0 0, 100% 0, 100% 80%, 0 100%);
   height: 120px;
 }
 
 .main {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2rem;
-  justify-content: center;
+  background: url('/src/assets/img/folder.svg') center/cover no-repeat fixed;
+  min-height: 100vh;
   padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
 }
 
 @media (max-width: 768px) {
@@ -26,6 +27,26 @@
   overflow-y: auto;
   white-space: pre;
   font-family: 'Courier New', monospace;
+}
+
+.grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+}
+
+.preview,
+.lint {
+  flex: 1 1 45%;
+  max-height: 400px;
+  overflow: auto;
+}
+
+@media (max-width: 768px) {
+  .preview,
+  .lint {
+    flex: 1 1 100%;
+  }
 }
 
 .buttons {
@@ -47,7 +68,7 @@
 }
 
 .btnGreen {
-  background: var(--green-btn);
+  background: var(--green);
   color: #000;
 }
 
@@ -56,12 +77,24 @@
 }
 
 .btnRed {
-  background: var(--red-btn);
+  background: var(--red);
   color: #000;
 }
 
 .btnRed:hover:not(:disabled) {
   background: var(--red-hov);
+}
+
+.minAssist {
+  color: var(--grey-text);
+  text-align: center;
+}
+
+.lintBox {
+  background: #FFEEDB;
+  border: 2px dashed #FFA726;
+  padding: 1rem;
+  overflow: auto;
 }
 
 .btnGrey {

--- a/client/src/hooks/useJsonFile.js
+++ b/client/src/hooks/useJsonFile.js
@@ -1,0 +1,39 @@
+// Hook to manage JSON file data and lint
+import { useState } from 'react';
+import api from '../api/axios';
+import checkJsonConsistency from '../utils/checkJsonConsistency';
+
+export default function useJsonFile() {
+  const [jsonData, setJsonData] = useState(null);
+  const [issues, setIssues] = useState([]);
+  const [lintResult, setLintResult] = useState('');
+
+  // Parse file and collect issues
+  const handleSelectFile = (file) => {
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      try {
+        const data = JSON.parse(e.target.result);
+        setJsonData(data);
+        setIssues(checkJsonConsistency(data));
+      } catch {
+        setIssues(['JSON inválido']);
+      }
+    };
+    reader.readAsText(file);
+  };
+
+  // Upload and get lint text
+  const handleUpload = async () => {
+    if (!jsonData) return;
+    try {
+      const { data } = await api.post('/lint', jsonData);
+      setLintResult(data.text);
+    } catch {
+      /* ignored */
+    }
+  };
+
+  return { jsonData, issues, lintResult, handleSelectFile, handleUpload };
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -8,43 +8,13 @@ body {
 }
 
 :root {
-  --yellow-bg: #FCD858;
-  --yellow-top: #FFB326;
-  --green-btn: #32D657;
-  --green-hov: #24B648;
-  --red-btn: #E64444;
-  --red-hov: #C93636;
+  --bg-yellow: #FCD858;
+  --top-yellow: #FFB326;
+  --green: #32D657;
+  --green-hov: #25B24D;
+  --red: #E64444;
+  --red-hov: #C93434;
   --grey-btn: #F0F0F0;
-  --grey-text: #9A9A9A;
+  --grey-text: #B0B0B0;
 }
 
-.folder-bg {
-  position: relative;
-  min-height: 100vh;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-}
-
-.folder-bg::before {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 25%;
-  width: 50%;
-  height: 60px;
-  background: #f6d58b;
-  border-radius: 25px 25px 0 0;
-}
-
-.folder-bg::after {
-  content: '';
-  position: absolute;
-  top: 40px;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: #f7e3a5;
-  border-radius: 50px;
-  z-index: -1;
-}


### PR DESCRIPTION
## Summary
- overhaul style tokens and folder background
- replace accordion with lint panel
- move inconsistency panel and add min assist label
- update main layout with ActionButtons component
- add small hook example

## Testing
- `npm test` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*
- `PYTHONPATH=. pytest -q server/tests/test_files.py`

------
https://chatgpt.com/codex/tasks/task_e_684f8ae25760832abd4e1130d276b972