### PR TITLE
Rediseño responsive con Tailwind

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -11,28 +11,26 @@ function Inner() {
   const [min, setMin] = useState('3');
 
   return (
-    <div className="relative w-[1440px] h-[1024px] bg-[#FFF9F4]">
-      <h1 className="absolute w-[701px] h-[39px] left-[369px] top-[46px] font-inter font-bold text-[32px] tracking-[0.2em]">
-        Gestor de Puestos &amp; Asistencias
-      </h1>
-      
-      <div className="absolute w-[941px] h-[803px] left-[250px] top-[106px] bg-[#EBF0FF] shadow-[0px_4px_16px_rgba(0,0,1,0.25)]">
-        <div className="flex flex-col items-center">
-          <ActionButtons min={min} setMin={setMin} />
-          
-          <div className="mt-[100px] flex gap-12">
-            <div className="w-[411px]">
-              <h3 className="mb-4 font-fira-code font-normal text-[15px] tracking-[0.2em]">Vista previa del archivo</h3>
-              <JsonPreview />
-            </div>
-            
-            <LintPanel />
+    <main className="min-h-screen bg-[#FFF9F4] flex flex-col">
+      <header className="py-6">
+        <h1 className="text-3xl font-bold text-center tracking-widest">Gestor de Puestos &amp; Asistencias</h1>
+      </header>
+
+      <section className="flex-grow bg-[#EBF0FF] shadow-custom max-w-3xl mx-auto px-4 py-8 flex flex-col">
+        <ActionButtons min={min} setMin={setMin} />
+
+        <div className="mt-10 grid md:grid-cols-2 gap-8">
+          <div>
+            <h3 className="mb-2 font-fira-code text-sm tracking-widest">Vista previa del archivo</h3>
+            <JsonPreview />
           </div>
-          
-          <IssuesPanel />
+
+          <LintPanel />
         </div>
-      </div>
-    </div>
+
+        <IssuesPanel />
+      </section>
+    </main>
   );
 }
 

--- a/client/src/components/ActionButtons.jsx
+++ b/client/src/components/ActionButtons.jsx
@@ -6,13 +6,15 @@ import MinAssistText from './MinAssistText';
 
 export default function ActionButtons({ min, setMin }) {
   return (
-    <div className="flex flex-col items-center gap-16">
+    <div className="flex flex-col items-center gap-6 flex-1">
       <FileUploader />
       <div className="flex items-center gap-4">
         <MinAssistText />
         <MinDaysInput value={min} onChange={setMin} />
       </div>
-      <OptimizeButton minDays={min} />
+      <div className="mt-auto flex justify-center w-full">
+        <OptimizeButton minDays={min} />
+      </div>
     </div>
   );
 }

--- a/client/src/components/FileUploader.jsx
+++ b/client/src/components/FileUploader.jsx
@@ -34,7 +34,7 @@ export default function FileUploader() {
   };
 
   return (
-    <div className="relative">
+    <div className="relative w-full max-w-md">
       <input
         id="file-input"
         type="file"
@@ -44,13 +44,11 @@ export default function FileUploader() {
       />
       <label
         htmlFor="file-input"
-        className="w-[371px] h-[70px] flex items-center gap-6 bg-brand-uploadBtn text-black shadow-custom cursor-pointer"
+        className="w-full h-14 flex items-center justify-center gap-3 bg-brand-uploadBtn text-black shadow-custom cursor-pointer"
         aria-label="Cargar archivo"
       >
-        <div className="ml-3">
-          <FileIcon className="w-10 h-10" />
-        </div>
-        <span className="font-inter text-base tracking-[0.5em]">Subir archivo json</span>
+        <FileIcon className="w-6 h-6" />
+        <span className="tracking-widest">Cargar archivo</span>
       </label>
     </div>
   );

--- a/client/src/components/IssuesPanel.jsx
+++ b/client/src/components/IssuesPanel.jsx
@@ -8,9 +8,9 @@ export default function IssuesPanel() {
   if (!issues.length) return null;
 
   return (
-    <div className="mt-6 p-4 bg-gray-50 rounded-lg" role="alert">
-      <h2 className="text-lg font-medium text-brand-blue mt-6 mb-2 first:mt-0">Inconsistencias</h2>
-      <ul className="list-disc pl-5">
+    <div className="mt-4 bg-red-50 border-l-4 border-red-400 p-4 rounded-md text-red-800" role="alert">
+      <h2 className="font-medium mb-2">Inconsistencias</h2>
+      <ul className="list-disc pl-5 space-y-1 text-sm">
         {issues.map((i, idx) => (
           <li key={idx}>{i}</li>
         ))}

--- a/client/src/components/JsonPreview.jsx
+++ b/client/src/components/JsonPreview.jsx
@@ -6,20 +6,15 @@ export default function JsonPreview() {
 
   if (!summary) return null;
   const lines = JSON.stringify({ summary, sample }, null, 2).split('\n');
-  const preview = lines.slice(0, 10).join('\n') + (lines.length > 10 ? '\u2026' : '');
+  const limited = lines.slice(0, 20);
+  const preview = limited
+    .map((l, i) => `${String(i + 1).padStart(2, ' ')}  ${l}`)
+    .join('\n');
+  const ellipsis = lines.length > 20 ? '\n…' : '';
 
   return (
-    <div className="w-[411px] h-[385px] bg-brand-preview rounded-lg relative overflow-hidden">
-      <div className="w-[68.5px] h-full bg-brand-lineNumbers rounded-l-lg absolute left-0 top-0 font-fira-code font-bold text-[14px] text-white">
-        {Array.from({ length: 10 }, (_, i) => (
-          <div key={i} className="h-[35px] flex items-center justify-center tracking-[0.2em]">
-            {i + 1}
-          </div>
-        ))}
-      </div>
-      <pre className="pl-[80px] pt-4 text-white font-fira-code text-sm">
-        <code className="block whitespace-pre">{preview}</code>
-      </pre>
-    </div>
+    <pre className="bg-gray-900 text-green-300 overflow-y-auto max-h-96 p-4 rounded-lg text-sm" aria-label="JSON preview">
+      <code className="whitespace-pre">{preview + ellipsis}</code>
+    </pre>
   );
 }

--- a/client/src/components/LintPanel.jsx
+++ b/client/src/components/LintPanel.jsx
@@ -14,20 +14,10 @@ export default function LintPanel() {
   if (!lint.length) return null;
 
   return (
-    <div className="w-[411px] h-[385px] bg-brand-preview rounded-lg relative overflow-hidden">
-      <div className="w-[68.5px] h-full bg-brand-lineNumbers rounded-l-lg absolute left-0 top-0 font-fira-code font-bold text-[14px] text-white">
-        {Array.from({ length: 10 }, (_, i) => (
-          <div key={i} className="h-[35px] flex items-center justify-center tracking-[0.2em]">
-            {i + 1}
-          </div>
-        ))}
-      </div>
-      <div className="pl-[80px] pt-4">
-        <h2 className="text-white font-fira-code text-sm mb-2">Lint Results</h2>
-        <pre className="text-white font-fira-code text-sm whitespace-pre">
-          {lint.map((e, i) => `${e.severity}: ${e.msg}`).join('\n')}
-        </pre>
-      </div>
-    </div>
+    <pre className="bg-gray-900 text-green-300 overflow-y-auto max-h-96 p-4 rounded-lg text-sm" aria-label="Lint results">
+      <code className="whitespace-pre">
+        {lint.map((e, i) => `${i + 1} ${e.severity}: ${e.msg}`).join('\n')}
+      </code>
+    </pre>
   );
 }

--- a/client/src/components/MinAssistText.jsx
+++ b/client/src/components/MinAssistText.jsx
@@ -1,7 +1,7 @@
 // Static text for minimum assists
 export default function MinAssistText() {
   return (
-    <label htmlFor="min-days" className="w-[617px] font-inter font-normal text-[20px] tracking-[0.4em]">
+    <label htmlFor="min-days" className="block text-lg tracking-widest">
       Mínimo de asistencias semanales
     </label>
   );

--- a/client/src/components/MinDaysInput.jsx
+++ b/client/src/components/MinDaysInput.jsx
@@ -11,15 +11,14 @@ export default function MinDaysInput({ value, onChange }) {
   };
 
   return (
-    <div className="w-[151px]">
-      <input
-        id="min-days"
-        type="text"
-        value={value}
-        onChange={handle}
-        disabled={!fileId}
-        className="w-full h-[36px] px-4 bg-brand-inputBg shadow-custom rounded-lg text-center font-inter text-[32px] tracking-[0.5em] focus:outline-none"
-      />
-    </div>
+    <input
+      id="min-days"
+      type="text"
+      placeholder="Minimo de Asistencias"
+      value={value}
+      onChange={handle}
+      disabled={!fileId}
+      className="w-24 sm:w-32 px-3 py-1 bg-brand-inputBg shadow-custom rounded-lg text-center font-inter text-xl tracking-[0.5em] focus:outline-none"
+    />
   );
 }

--- a/client/src/components/OptimizeButton.jsx
+++ b/client/src/components/OptimizeButton.jsx
@@ -16,18 +16,14 @@ export default function OptimizeButton({ minDays }) {
   };
 
   return (
-    <div className="relative">
-      <button
-        className="w-[263px] h-[70px] flex items-center gap-4 bg-brand-optimizeBtn shadow-custom disabled:opacity-50 disabled:cursor-not-allowed"
-        onClick={click}
-        disabled={!fileId || hasErrors}
-        aria-label="Optimizar"
-      >
-        <div className="ml-3">
-          <Settings className="w-12 h-12" />
-        </div>
-        <span className="font-inter text-base tracking-[0.5em]">Optimizar</span>
-      </button>
-    </div>
+    <button
+      className="flex items-center justify-center gap-2 bg-brand-optimizeBtn text-brand-blue w-full max-w-xs py-4 rounded-lg shadow-custom disabled:opacity-50 disabled:cursor-not-allowed"
+      onClick={click}
+      disabled={!fileId || hasErrors}
+      aria-label="Optimizar"
+    >
+      <Settings className="w-6 h-6" />
+      <span className="tracking-widest font-medium">Optimizar</span>
+    </button>
   );
 }


### PR DESCRIPTION
## Summary
- restructure layout semantics in `App.jsx`
- center optimize button at the bottom
- style components with Tailwind for responsive UI
- dark styled JSON and lint previews with optional numbering
- show issues panel only when needed with alert styles

## Testing
- `PYTHONPATH=. pytest server/tests/test_files.py -q`
- `npm test --silent` *(fails: Invalid Chai property)*

------
https://chatgpt.com/codex/tasks/task_e_6850ae5822dc832aa2a70eef62994d22