### PR TITLE
Fix imports for serverless execution

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -5,8 +5,18 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from .routes import files, optimization
-from .scheduler import scheduler
+# When executed directly, __package__ is not set and relative imports fail.
+# Adjust sys.path so we can import the modules as part of the ``server`` package.
+import sys
+from pathlib import Path
+
+if __package__ is None or __package__ == "":
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from server.routes import files, optimization
+    from server.scheduler import scheduler
+else:
+    from .routes import files, optimization
+    from .scheduler import scheduler
 
 app = FastAPI(title="Opt Puestos API")
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,4 +3,4 @@ pydantic
 uvicorn
 apscheduler
 python-multipart
-httpx
+httpx<0.27

--- a/server/scheduler.py
+++ b/server/scheduler.py
@@ -9,7 +9,13 @@ import logging
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 
-from .utils import storage
+import sys
+
+if __package__ is None or __package__ == "":
+    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    from server.utils import storage
+else:
+    from .utils import storage
 
 LOG_PATH = Path("/var/log/opt-puestos/cleanup.log")
 LOG_PATH.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- handle direct execution of `main.py` and `scheduler.py`
- pin `httpx` version for compatible `TestClient`

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850bd9b5ce8832a88cb0fe98c037851