### PR TITLE
Fix server path for Vercel

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -11,7 +11,7 @@ import sys
 from pathlib import Path
 
 if __package__ is None or __package__ == "":
-    sys.path.append(str(Path(__file__).resolve().parent.parent))
+    sys.path.append(str(Path(__file__).resolve().parent))
     from server.routes import files, optimization
     from server.scheduler import scheduler
 else:

--- a/server/tests/test_files.py
+++ b/server/tests/test_files.py
@@ -4,6 +4,12 @@ from __future__ import annotations
 
 import json
 from fastapi.testclient import TestClient
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+if str(ROOT_DIR) not in sys.path:
+    sys.path.insert(0, str(ROOT_DIR))
 
 from server.main import app
 


### PR DESCRIPTION
## Summary
- adjust `sys.path` to include current directory
- ensure tests can import `server` module

## Testing
- `pytest -q`
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c3752e68832a88a9eaa9f63bfe9e