### PR TITLE
Fix imports when server directory is root

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -11,10 +11,18 @@ import sys
 from pathlib import Path
 
 if __package__ is None or __package__ == "":
+    # When executed as ``python main.py`` from the ``server`` folder,
+    # the package name is empty and absolute imports using the
+    # ``server.`` prefix fail. We add the current directory to the
+    # module search path and import the modules without the prefix so
+    # the code works both locally and when deployed with this folder as
+    # the project root (e.g. on Vercel).
     sys.path.append(str(Path(__file__).resolve().parent))
-    from server.routes import files, optimization
-    from server.scheduler import scheduler
+    from routes import files, optimization
+    from scheduler import scheduler
 else:
+    # When imported as part of the ``server`` package (e.g. ``uvicorn
+    # server.main:app``) we can rely on relative imports.
     from .routes import files, optimization
     from .scheduler import scheduler
 


### PR DESCRIPTION
## Summary
- allow running `main.py` when the deployed root is the `server` folder

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6850c6beb5ec832ab0b145c7aa4e0dec