### PR TITLE
Add optimization workflow with polling and Firebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,39 @@ La interfaz se rehízo utilizando exclusivamente utilidades de Tailwind CSS sigu
 - **Responsive**: Se mantuvieron las proporciones en todos los breakpoints
 
 El rediseño se logró sin CSS externo, utilizando únicamente las capacidades de Tailwind CSS a través de la configuración `tailwind.config.js` y clases utilitarias.
+
+## Dependencias instaladas
+- @testing-library/react@^14.1.2
+- @vitejs/plugin-react@^4.2.0
+- apscheduler
+- autoprefixer@^10.4.21
+- axios@^1.6.7
+- fastapi
+- firebase-admin
+- httpx>=0.28,<0.29
+- jsdom@^22.1.0
+- lucide-react@^0.516.0
+- numpy
+- pandas
+- postcss@^8.5.6
+- pulp
+- pydantic
+- python-multipart
+- react-dom@^18.2.0
+- react-hot-toast@^2.4.1
+- react@^18.2.0
+- tailwindcss@^3.4.17
+- uvicorn
+- vite@^5.0.10
+- vitest@^3.2.3
+
+## Variables de entorno
+- API_URL: 
+- GOOGLE_APPLICATION_CREDENTIALS: 
+- VITE_API_URL: 
+
+## Instalacion
+```bash
+pip install -r requirements.txt
+npm install
+```

--- a/client/__tests__/FileFlow.test.jsx
+++ b/client/__tests__/FileFlow.test.jsx
@@ -7,7 +7,7 @@ import FileUploader from '../src/components/FileUploader.jsx';
 describe('UI pieces', () => {
   it('renders upload button', () => {
     render(<FileProvider><FileUploader /></FileProvider>);
-    expect(screen.getByText('Cargar archivo')).toBeInTheDocument();
+    expect(screen.getByText('Cargar archivo')).not.toBeNull();
   });
 
   it('validates min days regex', () => {

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -5,10 +5,27 @@ import ActionButtons from './components/ActionButtons';
 import IssuesPanel from './components/IssuesPanel';
 import { FileProvider } from './context/FileContext';
 import { Toaster } from 'react-hot-toast';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
+import JobMonitor from './components/JobMonitor';
+import api from './api/axios';
 
 function Inner() {
   const [min, setMin] = useState('1');
+  const [jobId, setJobId] = useState(() => localStorage.getItem('job_id'));
+
+  const startJob = async (fileId, m) => {
+    try {
+      const { data } = await api.post('/optimization', { file_id: fileId, min_days: m });
+      setJobId(data.job_id);
+      localStorage.setItem('job_id', data.job_id);
+    } catch (_) {}
+  };
+
+  const finishJob = (newMin) => {
+    localStorage.removeItem('job_id');
+    setJobId(null);
+    if (newMin) setMin(String(newMin));
+  };
 
   return (
     <main className="min-h-screen bg-[#FFF9F4] flex flex-col">
@@ -17,7 +34,7 @@ function Inner() {
       </header>
 
       <section className="flex-grow bg-[#EBF0FF] shadow-custom max-w-3xl mx-auto px-4 py-8 flex flex-col">
-        <ActionButtons min={min} setMin={setMin} />
+        <ActionButtons min={min} setMin={setMin} onStart={startJob} />
 
         <div className="mt-10 grid md:grid-cols-2 gap-8">
           <div>
@@ -29,6 +46,7 @@ function Inner() {
         </div>
 
         <IssuesPanel />
+        {jobId && <JobMonitor jobId={jobId} onFinish={finishJob} />}
       </section>
     </main>
   );

--- a/client/src/components/ActionButtons.jsx
+++ b/client/src/components/ActionButtons.jsx
@@ -4,7 +4,7 @@ import OptimizeButton from './OptimizeButton';
 import MinDaysInput from './MinDaysInput';
 import MinAssistText from './MinAssistText';
 
-export default function ActionButtons({ min, setMin }) {
+export default function ActionButtons({ min, setMin, onStart }) {
   return (
     <div className="flex flex-col items-center gap-6 flex-1">
       <FileUploader />
@@ -13,7 +13,7 @@ export default function ActionButtons({ min, setMin }) {
         <MinDaysInput value={min} onChange={setMin} />
       </div>
       <div className="flex justify-center w-full">
-        <OptimizeButton minDays={min} />
+        <OptimizeButton minDays={min} onStart={onStart} />
       </div>
     </div>
   );

--- a/client/src/components/FailureModal.jsx
+++ b/client/src/components/FailureModal.jsx
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+export default function FailureModal({ error, onRetry }) {
+  const [val, setVal] = useState('');
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+      <div className="bg-red-100 p-6 rounded-lg text-center">
+        <h2 className="text-xl font-bold mb-2">No se encontró solución</h2>
+        <p className="mb-2">{error}</p>
+        <input className="border px-2 py-1" value={val} onChange={(e)=>setVal(e.target.value)} placeholder="Nuevo mínimo" />
+        <div className="mt-4 flex justify-center gap-4">
+          <button className="px-4 py-2 bg-gray-300" onClick={onRetry}>Regresar</button>
+          <button className="px-4 py-2 bg-blue-500 text-white" onClick={()=>onRetry(val)}>Reintentar</button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/JobMonitor.jsx
+++ b/client/src/components/JobMonitor.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import api from '../api/axios';
+import SuccessModal from './SuccessModal';
+import FailureModal from './FailureModal';
+
+const MESSAGES = [
+  'Calculando asignaciones…',
+  'Ajustando preferencias…',
+  'Resolviendo restricciones…'
+];
+
+export default function JobMonitor({ jobId, onFinish }) {
+  const [state, setState] = useState('queued');
+  const [msgIdx, setMsgIdx] = useState(0);
+  const [kpis, setKpis] = useState(null);
+
+  useEffect(() => {
+    if (!jobId) return;
+    const poll = setInterval(async () => {
+      try {
+        const { data } = await api.get(`/optimization/${jobId}/status`);
+        setState(data.state);
+        if (data.state === 'success') {
+          setKpis({ score: data.score, preferences: data.preferences, assigned: data.assigned });
+          clearInterval(poll);
+        }
+        if (data.state === 'failure') {
+          setKpis({ error: data.error });
+          clearInterval(poll);
+        }
+      } catch (_) {}
+    }, 3000);
+    return () => clearInterval(poll);
+  }, [jobId]);
+
+  useEffect(() => {
+    if (!jobId) return;
+    const rot = setInterval(() => setMsgIdx((m) => (m + 1) % MESSAGES.length), 4000);
+    return () => clearInterval(rot);
+  }, [jobId]);
+
+  if (!jobId || state === 'success' || state === 'failure') {
+    if (state === 'success') return <SuccessModal kpis={kpis} onClose={onFinish} />;
+    if (state === 'failure') return <FailureModal error={kpis?.error} onRetry={onFinish} />;
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+      <div className="bg-white p-6 rounded-lg flex flex-col items-center gap-4">
+        <svg className="animate-spin h-8 w-8" viewBox="0 0 24 24">
+          <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+          <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
+        </svg>
+        <p>{MESSAGES[msgIdx]}</p>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/OptimizeButton.jsx
+++ b/client/src/components/OptimizeButton.jsx
@@ -1,18 +1,13 @@
 // Button to trigger optimization
-import api from '../api/axios';
-import { toast } from 'react-hot-toast';
 import { useFile } from '../context/FileContext';
 import { Settings } from 'lucide-react';
 
-export default function OptimizeButton({ minDays }) {
+export default function OptimizeButton({ minDays, onStart }) {
   const { fileId, lint } = useFile();
   const hasErrors = lint.some((e) => e.severity === 'error');
 
-  const click = async () => {
-    try {
-      await api.post('/optimization', { file_id: fileId, min_days: Number(minDays) });
-      toast.success('Optimización en cola');
-    } catch (_) {}
+  const click = () => {
+    if (onStart) onStart(fileId, Number(minDays));
   };
 
   return (

--- a/client/src/components/SuccessModal.jsx
+++ b/client/src/components/SuccessModal.jsx
@@ -1,0 +1,13 @@
+export default function SuccessModal({ kpis, onClose }) {
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/50">
+      <div className="bg-green-100 p-6 rounded-lg text-center">
+        <h2 className="text-xl font-bold mb-2">¡Optimización exitosa!</h2>
+        <p>Score: {kpis?.score?.toFixed(2)}</p>
+        <p>% preferencias: {(kpis?.preferences * 100).toFixed(0)}%</p>
+        <p>% empleados asignados: {(kpis?.assigned * 100).toFixed(0)}%</p>
+        <button className="mt-4 px-4 py-2 bg-green-500 text-white" onClick={onClose}>Ver resultados</button>
+      </div>
+    </div>
+  );
+}

--- a/scripts/update_readme.py
+++ b/scripts/update_readme.py
@@ -1,0 +1,75 @@
+import json
+import re
+from pathlib import Path
+import os
+
+ROOT = Path(__file__).resolve().parents[1]
+server_req = ROOT / 'server' / 'requirements.txt'
+client_pkg = ROOT / 'client' / 'package.json'
+readme = ROOT / 'README.md'
+
+# Parse python requirements
+py_deps = []
+if server_req.exists():
+    for line in server_req.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        name_ver = line
+        m = re.match(r'([A-Za-z0-9_\-]+)(.*)', line)
+        if m:
+            name, ver = m.groups()
+            ver = ver.strip()
+            if ver.startswith('=='):
+                pkg = f"{name}@{ver[2:]}"
+            else:
+                pkg = f"{name}{ver}"
+        else:
+            pkg = name_ver
+        py_deps.append(pkg)
+
+# Parse JS dependencies
+js_deps = []
+if client_pkg.exists():
+    data = json.loads(client_pkg.read_text())
+    for section in ('dependencies', 'devDependencies'):
+        for name, ver in data.get(section, {}).items():
+            js_deps.append(f"{name}@{ver}")
+
+# Detect env vars
+env_vars = set()
+# from .env.example
+env_example = ROOT / '.env.example'
+if env_example.exists():
+    for line in env_example.read_text().splitlines():
+        line = line.strip()
+        if line and not line.startswith('#') and '=' in line:
+            env_vars.add(line.split('=')[0])
+
+# search Python files
+for path in (ROOT / 'server').rglob('*.py'):
+    if not path.is_file():
+        continue
+    text = path.read_text()
+    env_vars.update(re.findall(r"os\.getenv\(['\"]([^'\"]+)['\"]", text))
+    env_vars.update(re.findall(r"os\.environ\.get\(['\"]([^'\"]+)['\"]", text))
+
+# search JS files
+for path in (ROOT / 'client').rglob('*.js*'):
+    if 'node_modules' in path.parts or not path.is_file():
+        continue
+    text = path.read_text()
+    env_vars.update(re.findall(r"import\.meta\.env\.([A-Za-z0-9_]+)", text))
+    env_vars.update(re.findall(r"process\.env\.([A-Za-z0-9_]+)", text))
+
+dep_section = '## Dependencias instaladas\n' + '\n'.join(f'- {d}' for d in sorted(py_deps + js_deps)) + '\n'
+vars_section = '## Variables de entorno\n' + '\n'.join(f'- {v}: ' for v in sorted(env_vars)) + '\n'
+install_section = '## Instalacion\n```bash\npip install -r requirements.txt\nnpm install\n```\n'
+
+content = readme.read_text()
+for header in ('## Dependencias instaladas', '## Variables de entorno', '## Instalacion'):
+    pattern = re.compile(header + r'.*?(?=\n## |\Z)', re.S)
+    content = pattern.sub('', content)
+
+content = content.rstrip() + '\n\n' + dep_section + '\n' + vars_section + '\n' + install_section
+readme.write_text(content)

--- a/server/main.py
+++ b/server/main.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
-from routes import files, optimization
-from scheduler import scheduler
+from .routes import files, optimization
+from .scheduler import scheduler
 
 app = FastAPI(title="Opt Puestos API")
 

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,4 +3,8 @@ pydantic
 uvicorn
 apscheduler
 python-multipart
-httpx<0.27
+httpx>=0.28,<0.29
+pulp
+pandas
+numpy
+firebase-admin

--- a/server/routes/files.py
+++ b/server/routes/files.py
@@ -10,8 +10,8 @@ from uuid import UUID
 from fastapi import APIRouter, UploadFile, File, HTTPException
 from fastapi.responses import JSONResponse
 
-from models import FileResponse, Summary, LintResult, LintMessage
-from utils import storage
+from ..models import FileResponse, Summary, LintResult, LintMessage
+from ..utils import storage
 
 router = APIRouter(prefix="/api/v1/files", tags=["files"])
 

--- a/server/routes/optimization.py
+++ b/server/routes/optimization.py
@@ -2,16 +2,37 @@
 
 from __future__ import annotations
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
-from models import OptimizationRequest
+from ..models import OptimizationRequest
+from ..utils.optimizer import launch_job, get_status
+from ..utils import storage
 
 router = APIRouter(prefix="/api/v1/optimization", tags=["optimization"])
 
 
 @router.post("")
 def optimize(payload: OptimizationRequest) -> dict:
-    """Pretend to run an optimization job."""
+    """Launch a background optimization job."""
 
-    # In a real implementation this would trigger background processing.
-    return {"status": "queued", "file_id": str(payload.file_id), "min_days": payload.min_days}
+    if payload.file_id not in storage.FILES:
+        raise HTTPException(status_code=404, detail="file not found")
+    job_id = launch_job(payload.file_id, payload.min_days)
+    return {"job_id": job_id}
+
+
+@router.get("/{job_id}/status")
+def job_status(job_id: str) -> dict:
+    job = get_status(job_id)
+    resp = {"state": job.status}
+    if job.status == "success":
+        resp.update(job.result["kpis"])
+    if job.error:
+        resp["error"] = job.error
+    return resp
+
+
+@router.get("/{job_id}/log")
+def job_log(job_id: str) -> dict:
+    job = get_status(job_id)
+    return {"log": job.log}

--- a/server/scheduler.py
+++ b/server/scheduler.py
@@ -9,7 +9,7 @@ import logging
 from apscheduler.schedulers.background import BackgroundScheduler
 from apscheduler.triggers.cron import CronTrigger
 
-from utils import storage
+from .utils import storage
 
 # Configure simple logging
 logging.basicConfig(level=logging.INFO)

--- a/server/tests/test_files.py
+++ b/server/tests/test_files.py
@@ -48,3 +48,15 @@ def test_upload_missing_key() -> None:
     )
     assert resp.status_code == 422
     assert resp.json()["errors"][0]["path"] == "Employees"
+
+def test_optimize_flow() -> None:
+    resp = client.post(
+        "/api/v1/files",
+        files={"file": ("test.json", json.dumps(SAMPLE), "application/json")},
+    )
+    file_id = resp.json()["id"]
+    resp = client.post("/api/v1/optimization", json={"file_id": file_id, "min_days": 1})
+    assert resp.status_code == 200
+    job_id = resp.json()["job_id"]
+    status = client.get(f"/api/v1/optimization/{job_id}/status").json()
+    assert "state" in status

--- a/server/utils/optimizer.py
+++ b/server/utils/optimizer.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import uuid
+import threading
+import os
+from dataclasses import dataclass
+from typing import Dict, Any
+
+from firebase_admin import firestore, initialize_app, credentials
+
+from . import storage
+from .solver import run_optimization
+
+# Initialize Firebase if credentials provided
+try:
+    initialize_app(credentials.Certificate(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")))
+    db = firestore.client()
+except Exception:
+    db = None
+
+@dataclass
+class JobRecord:
+    file_id: uuid.UUID
+    min_days: int
+    status: str = "queued"
+    result: Dict[str, Any] | None = None
+    error: str | None = None
+    log: str = ""
+
+JOBS: Dict[str, JobRecord] = {}
+
+
+def _run(job_id: str, file_id: uuid.UUID, min_days: int) -> None:
+    job = JOBS[job_id]
+    job.status = "running"
+    try:
+        data = storage.load_json(file_id)
+        result = run_optimization(data, min_days)
+        job.result = result
+        job.status = "success"
+        if db:
+            doc = {
+                "assignments": result["assignments"],
+                "kpis": result["kpis"],
+                "timestamp": firestore.SERVER_TIMESTAMP,
+                "minAttendance": min_days,
+                "file_id": str(file_id),
+            }
+            db.collection("optimizations").document(job_id).set(doc)
+    except Exception as exc:
+        job.status = "failure"
+        job.error = str(exc)
+        if db:
+            doc = {
+                "status": "failure",
+                "reason": str(exc),
+                "timestamp": firestore.SERVER_TIMESTAMP,
+                "minAttendance": min_days,
+                "file_id": str(file_id),
+            }
+            db.collection("optimizations").document(job_id).set(doc)
+
+
+def launch_job(file_id: uuid.UUID, min_days: int) -> str:
+    job_id = str(uuid.uuid4())
+    JOBS[job_id] = JobRecord(file_id=file_id, min_days=min_days)
+    thread = threading.Thread(target=_run, args=(job_id, file_id, min_days), daemon=True)
+    thread.start()
+    record = storage.FILES[file_id]
+    record.job_id = job_id
+    storage.FILES[file_id] = record
+    return job_id
+
+def get_status(job_id: str) -> JobRecord:
+    return JOBS[job_id]
+

--- a/server/utils/solver.py
+++ b/server/utils/solver.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from typing import Dict, Any, Tuple
+
+import pandas as pd
+import numpy as np
+from pulp import LpProblem, LpMaximize, LpVariable, LpBinary, LpInteger, lpSum, value, PULP_CBC_CMD
+
+
+def run_optimization(data: Dict[str, Any], min_attendance: int) -> Dict[str, Any]:
+    Employees = data['Employees']
+    Desks = data['Desks']
+    Days = data['Days']
+    Groups = data['Groups']
+    Zones = data['Zones']
+    Desks_Z = data['Desks_Z']
+    Desks_E = data['Desks_E']
+    Employees_G = data['Employees_G']
+    Days_E = data['Days_E']
+
+    compat = {(e, d): 1 if d in Desks_E[e] else 0 for e in Employees for d in Desks}
+    pref = {(e, t): 1 if t in Days_E[e] else 0 for e in Employees for t in Days}
+
+    M = len(Desks)
+    W1 = 100
+    W2 = 5
+    W3 = 10
+    W4 = 1
+    W5 = 1
+
+    prob = LpProblem('AsignacionPuestos', LpMaximize)
+
+    x = LpVariable.dicts('x', (Employees, Desks, Days), cat=LpBinary)
+    w = LpVariable.dicts('w', (Employees, Days), cat=LpBinary)
+    m = LpVariable.dicts('m', (Groups, Days), cat=LpBinary)
+    y = LpVariable.dicts('y', Employees, cat=LpBinary)
+    u = LpVariable.dicts('u', (Employees, Desks), cat=LpBinary)
+    puesto = LpVariable.dicts('puesto', Employees, cat=LpBinary)
+    solo = LpVariable.dicts('solo', (Groups, Zones, Days), cat=LpBinary)
+    n = LpVariable.dicts('n', (Groups, Zones, Days), lowBound=0, cat=LpInteger)
+    k = LpVariable.dicts('k', Employees, lowBound=0, cat=LpInteger)
+
+    prob += (
+        W1 * lpSum(y[e] for e in Employees)
+        + W2 * lpSum(k[e] for e in Employees)
+        - W3 * lpSum((1 - pref[e, t]) * w[e][t] for e in Employees for t in Days)
+        - W4 * lpSum(solo[g][z][t] for g in Groups for z in Zones for t in Days)
+        - W5 * lpSum((1 - puesto[e]) for e in Employees)
+    )
+
+    for e in Employees:
+        for d in Desks:
+            for t in Days:
+                prob += x[e][d][t] <= compat[(e, d)]
+
+    for d in Desks:
+        for t in Days:
+            prob += lpSum(x[e][d][t] for e in Employees) <= 1
+
+    for e in Employees:
+        for t in Days:
+            prob += w[e][t] == lpSum(x[e][d][t] for d in Desks)
+
+    for e in Employees:
+        prob += lpSum(w[e][t] for t in Days) >= min_attendance
+
+    for e in Employees:
+        prob += y[e] <= lpSum(w[e][t] for t in Days)
+
+    for g in Groups:
+        prob += lpSum(m[g][t] for t in Days) == 1
+
+    for g in Groups:
+        for e in Employees_G[g]:
+            for t in Days:
+                prob += w[e][t] >= m[g][t]
+
+    for e in Employees:
+        for d in Desks:
+            for t in Days:
+                prob += u[e][d] >= x[e][d][t]
+        prob += lpSum(u[e][d] for d in Desks) <= 1 + M * (1 - puesto[e])
+
+    for g in Groups:
+        for z in Zones:
+            for t in Days:
+                prob += n[g][z][t] == lpSum(x[e][d][t] for e in Employees_G[g] for d in Desks_Z[z])
+
+    for g in Groups:
+        for z in Zones:
+            for t in Days:
+                prob += n[g][z][t] <= 1 + M * (1 - solo[g][z][t])
+                prob += n[g][z][t] >= solo[g][z][t]
+
+    for e in Employees:
+        prob += k[e] == lpSum(w[e][t] for t in Days) - min_attendance
+
+    prob.solve(PULP_CBC_CMD(msg=False))
+
+    assignments = [
+        {"employee": e, "desk": d, "day": t}
+        for e in Employees for d in Desks for t in Days if x[e][d][t].value() == 1
+    ]
+
+    total_w = sum(w[e][t].value() for e in Employees for t in Days)
+    pref_w = sum(w[e][t].value() * pref[e, t] for e in Employees for t in Days)
+    pref_pct = 0 if total_w == 0 else pref_w / total_w
+    assigned_pct = sum(y[e].value() for e in Employees) / len(Employees)
+
+    result = {
+        "assignments": assignments,
+        "kpis": {
+            "score": value(prob.objective),
+            "preferences": pref_pct,
+            "assigned": assigned_pct,
+        },
+    }
+    return result

--- a/server/utils/storage.py
+++ b/server/utils/storage.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import Dict, Any, List
 from uuid import uuid4, UUID
 
-from models import FileRecord
+from ..models import FileRecord
 
 import tempfile
 


### PR DESCRIPTION
## Summary
- implement asynchronous optimization backend
- add solver using pulp and persistent Firestore storage
- expose optimization job endpoints
- integrate job monitor UI with spinners and modals
- allow retry after failure and resume after reload
- update tests for new behavior

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6850f6f20afc832aba3c8d0ac402e0ba